### PR TITLE
added a basic travis build script and health check

### DIFF
--- a/health.py
+++ b/health.py
@@ -1,0 +1,27 @@
+import requests
+import sys
+import time
+
+try:
+    url = sys.argv[1]
+    time.sleep(30)
+    r = requests.get(url)
+except requests.exceptions.ConnectionError as e:
+    print('Could not connect to "%s", reason: "%s"' % (str(sys.argv), str(e)))
+    exit(1)
+
+if r.status_code == 200:
+    j = r.json()
+    try:
+        status = j['status']
+        if status == 'UP':
+            print("Health check was passed")
+            exit(0)
+        else:
+            print('Health check did not pass. Current application status: "%s"' % str(status))
+    except KeyError as e:
+        print('Key "%s" not defined in json response: "%s"' % (str(e), str(j)))
+        exit(1)
+else:
+    print('Could not connect to "%s" return status was: "%s"' % (str(sys.argv), str(r.status_code)))
+    exit(1)

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,10 @@
             <artifactId>spring-boot-starter-websocket</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>

--- a/src/main/java/com/dalendev/finance/cryptobot/adapters/rest/binance/BaseAdapter.java
+++ b/src/main/java/com/dalendev/finance/cryptobot/adapters/rest/binance/BaseAdapter.java
@@ -20,13 +20,13 @@ public class BaseAdapter {
     protected final RestTemplate restTemplate;
     protected final ObjectMapper objectMapper;
 
-    @Value("${binance.api_key}")
+    @Value("${binance.api_key:123}")
     protected String apiKey;
 
-    @Value("${binance.api_secret}")
+    @Value("${binance.api_secret:123}")
     private String apiSecret;
 
-    @Value("${binance.base_url}")
+    @Value("${binance.base_url:http://localhost:8080}")
     protected String baseUrl;
 
     @Autowired

--- a/src/main/java/com/dalendev/finance/cryptobot/adapters/rest/binance/OrderAdapter.java
+++ b/src/main/java/com/dalendev/finance/cryptobot/adapters/rest/binance/OrderAdapter.java
@@ -25,7 +25,7 @@ import static com.dalendev.finance.cryptobot.util.PriceUtil.getRealPrice;
 @Component
 public class OrderAdapter extends BaseAdapter {
 
-    @Value("${binance.order_path}")
+    @Value("${binance.order_path:/api/v3/order}")
     private String orderPath;
 
     @Autowired

--- a/src/main/java/com/dalendev/finance/cryptobot/config/ApplicationBoot.java
+++ b/src/main/java/com/dalendev/finance/cryptobot/config/ApplicationBoot.java
@@ -14,11 +14,13 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.ApplicationListener;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 /**
  * @author daniele.orler
  */
+@Profile("!simpleBoot")
 @Component
 public class ApplicationBoot implements ApplicationListener<ApplicationReadyEvent> {
 

--- a/src/main/java/com/dalendev/finance/cryptobot/jobs/ExchangeInfoJob.java
+++ b/src/main/java/com/dalendev/finance/cryptobot/jobs/ExchangeInfoJob.java
@@ -6,6 +6,7 @@ import com.dalendev.finance.cryptobot.singletons.Exchange;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Profile;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -13,6 +14,7 @@ import org.springframework.stereotype.Component;
  * @author daniele.orler
  */
 
+@Profile("!simpleBoot")
 @Component
 public class ExchangeInfoJob {
 

--- a/src/main/java/com/dalendev/finance/cryptobot/jobs/PriceTickerJob.java
+++ b/src/main/java/com/dalendev/finance/cryptobot/jobs/PriceTickerJob.java
@@ -8,6 +8,7 @@ import com.google.common.eventbus.EventBus;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Profile;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -16,7 +17,7 @@ import java.util.List;
 /**
  * @author daniele.orler
  */
-
+@Profile("!simpleBoot")
 @Component
 public class PriceTickerJob {
 

--- a/travis.yml
+++ b/travis.yml
@@ -18,5 +18,5 @@ jobs:
       - python3 -V
       - pip3 -V
       - pip3 install requests
-      - nohup java -jar cryptobot/target/cryptobot-1.0-SNAPSHOT.jar &
+      - nohup java -jar cryptobot/target/cryptobot-1.0-SNAPSHOT.jar --spring.profiles.active=simpleBoot &
       - python3 health.py http://localhost:8080/health

--- a/travis.yml
+++ b/travis.yml
@@ -1,0 +1,22 @@
+dist: trusty
+sudo: required
+
+language: java
+jdk:
+- oraclejdk8
+
+cache:
+  directories:
+  - $HOME/.m2
+
+jobs:
+  include:
+    - stage: compile
+      script:
+      - mvn clean package
+      - sudo apt-get -y install python3-pip
+      - python3 -V
+      - pip3 -V
+      - pip3 install requests
+      - nohup java -jar cryptobot/target/cryptobot-1.0-SNAPSHOT.jar &
+      - python3 health.py http://localhost:8080/health


### PR DESCRIPTION
so added a basic travis build script that uses openjdk8 to build the project.

**Build steps:**
first it builds it
then installs python, pip and a lib called requests
then it starts the spring boot application that we just built
after 30 sec it runs the python health script to make sure the service started properly and checks the health endpoint.

since travis only supplies build agents with one dev kit on (in this case java), during the build i install python to be able to run the custom health script.

This script can be written in bash and curl but im not good with those :)

I can't setup the actual build on travis, only the person that owns the repo can do it, and then tell travis to start polling the repo.

To be able to run the application without having a mock running in the background i added a new profile called simpleBoot